### PR TITLE
feat(default global transaction use): add option to enable/disable global transaction (default=off)

### DIFF
--- a/migration-config.yaml
+++ b/migration-config.yaml
@@ -1,6 +1,6 @@
 db-connection:
-  url: ${URL}
-  databaseName: ${DB_NAME}
+  url: mongodb://localhost:27018/users?authMechanism=DEFAULT&directConnection=true
+  databaseName: testDb
   options:
     useNewUrlParser: true
     useUnifiedTopology: true

--- a/migration-config.yaml
+++ b/migration-config.yaml
@@ -7,3 +7,4 @@ db-connection:
 
 migrationsDir: src/migrations
 changelogCollectionName: migrations
+useDefaultTransaction: false

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -27,7 +27,7 @@ program
     try {
       const {
         'db-connection': { url, databaseName }
-      } = await configHelper.readConfig()
+      } = configHelper.readConfig()
       const mongoClient = new MongoClient(url, { maxPoolSize: 5, minPoolSize: 0, maxIdleTimeMS: 5000 })
       const dbInstance = mongoClient.db(databaseName)
       await mongoClient.connect()
@@ -50,7 +50,7 @@ program
     try {
       const {
         'db-connection': { url, databaseName }
-      } = await configHelper.readConfig()
+      } = configHelper.readConfig()
       const mongoClient = new MongoClient(url, { maxPoolSize: 5, minPoolSize: 0, maxIdleTimeMS: 5000 })
       const dbInstance = mongoClient.db(databaseName)
       await mongoClient.connect()
@@ -75,7 +75,7 @@ program
       const opts: any = {}
       const {
         'db-connection': { url, databaseName }
-      } = await configHelper.readConfig()
+      } = configHelper.readConfig()
 
       const mongoClient = new MongoClient(url, { maxPoolSize: 5, minPoolSize: 0, maxIdleTimeMS: 5000 })
       const dbInstance = mongoClient.db(databaseName)

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -12,6 +12,7 @@ export interface IConfiguration {
   migrationsDir: string
   changelogCollectionName: string
   fileExtension?: FileExtension
+  useDefaultTransaction?: boolean
 }
 
 export interface IDbConnection {

--- a/src/lib/commands/create.ts
+++ b/src/lib/commands/create.ts
@@ -8,12 +8,11 @@ import FileExtension from '../../enums/file-extension'
 
 export default async function create(name: string, options: any) {
   try {
-    const config = await configHelper.readConfig()
+    const config = configHelper.readConfig()
     if (!config) return console.error('Migration not initialized yet.')
 
     const migrationDirPath = config.migrationsDir
-    const sampleFile =
-      config.fileExtension === FileExtension.TS ? '../../samples/migration.txt' : '../../samples/migration.js.txt'
+    const sampleFile = config.fileExtension === FileExtension.TS ? '../../samples/migration.txt' : '../../samples/migration.js.txt'
 
     if (!isFileExist(migrationDirPath)) {
       mkdirSync(migrationDirPath)

--- a/src/lib/commands/down.ts
+++ b/src/lib/commands/down.ts
@@ -10,34 +10,42 @@ import isFileExist, { removeDirectory } from '../utils/file'
 import { getLatestMigrationBatch, getLatestMigrations, getMigrationForFile } from '../utils/migration-dir'
 
 export default async function down(db: Db, dbClient: MongoClient, options: any) {
-  const session = dbClient.startSession()
-  session.startTransaction()
+  const useDefaultTransaction = configHelper.readConfig().useDefaultTransaction ?? false
+  const hasGlobalTransaction = useDefaultTransaction || options.dryRun
+
+  let session = undefined
+  if (hasGlobalTransaction) {
+    session = dbClient.startSession()
+    session.startTransaction()
+  }
 
   try {
-    const config = await configHelper.readConfig()
+    const config = configHelper.readConfig()
     const migrationsToRollback = await getMigrationsToRollback(db, options)
 
     await rollbackMigrations(migrationsToRollback, db, config, session)
 
-    if (options.dryRun) {
-      await session.abortTransaction()
-      console.log(chalk.green('Dry run completed sucessfully'))
-    } else {
-      await session.commitTransaction()
-      console.log(chalk.green('Migration rollback sucessfully'))
+    if (hasGlobalTransaction) {
+      if (options.dryRun) {
+        await session?.abortTransaction()
+        console.log(chalk.green('Dry run completed sucessfully'))
+      } else {
+        await session?.commitTransaction()
+        console.log(chalk.green('Migration rollback sucessfully'))
+      }
     }
   } catch (error: any) {
-    await session.abortTransaction()
+    if (hasGlobalTransaction) await session?.abortTransaction()
     dbClient.close()
 
     throw error
   } finally {
-    session.endSession()
+    if (hasGlobalTransaction) session?.endSession()
     await removeDirectory('.cache', { recursive: true })
   }
 }
 
-async function rollbackMigrations(migrationsToRollback: IMigrationInfo[], db: Db, config: any, session: ClientSession) {
+async function rollbackMigrations(migrationsToRollback: IMigrationInfo[], db: Db, config: any, session?: ClientSession) {
   const model = new DB(db, session)
   const uniquemigrationIds = migrationsToRollback.map(m => m._id)
 
@@ -48,18 +56,14 @@ async function rollbackMigrations(migrationsToRollback: IMigrationInfo[], db: Db
       continue
     }
 
-    const { default: Migration } = await tsImport.load(
-      path.resolve(`${config.migrationsDir}/${appliedMigration.fileName}`)
-    )
+    const { default: Migration } = await tsImport.load(path.resolve(`${config.migrationsDir}/${appliedMigration.fileName}`))
     const migration: IMigration = new Migration()
 
     await migration.down(model)
     console.log(`${chalk.green(`Rolled back:  `)} ${appliedMigration.fileName}`)
   }
 
-  await db
-    .collection(config.changelogCollectionName)
-    .deleteMany({ _id: { $in: uniquemigrationIds as unknown as ObjectId[] } }, { session })
+  await db.collection(config.changelogCollectionName).deleteMany({ _id: { $in: uniquemigrationIds as unknown as ObjectId[] } }, { session })
 
   return uniquemigrationIds
 }

--- a/src/lib/commands/status.ts
+++ b/src/lib/commands/status.ts
@@ -5,7 +5,7 @@ import configHelper from '../helpers/config-helper'
 import { getAppliedMigrations, getMigrationFiles } from '../utils/migration-dir'
 
 export default async function status(db: Db, options?: any) {
-  const config = await configHelper.readConfig()
+  const config = configHelper.readConfig()
   let [migrationFiles, appliedMigrations] = await Promise.all([getMigrationFiles(), getAppliedMigrations(db)])
 
   const uniqueBatches = [...new Set(appliedMigrations.map(m => m.batchId))]

--- a/src/lib/helpers/config-helper.ts
+++ b/src/lib/helpers/config-helper.ts
@@ -7,7 +7,7 @@ import { IConfiguration } from '../../interface'
 import FileExtension from '../../enums/file-extension'
 
 class ConfigHelper {
-  async readConfig() {
+  readConfig() {
     const configFilePath = path.join(process.cwd(), 'migration-config.yaml')
 
     if (!isFileExist(configFilePath)) {

--- a/src/lib/utils/migration-dir.ts
+++ b/src/lib/utils/migration-dir.ts
@@ -7,7 +7,7 @@ import { IMigrationInfo } from '../../interface'
 import configHelper from '../helpers/config-helper'
 
 export async function migrationDirExist() {
-  const config = await configHelper.readConfig()
+  const config = configHelper.readConfig()
   if (!config) return console.error('Migration not initialized yet.')
 
   const migrationDirPath = config.migrationsDir
@@ -16,7 +16,7 @@ export async function migrationDirExist() {
 }
 
 export async function createMigrationDir() {
-  const config = await configHelper.readConfig()
+  const config = configHelper.readConfig()
   if (!config) return console.error('Migration not initialized yet.')
 
   const migrationDirPath = config.migrationsDir
@@ -24,7 +24,7 @@ export async function createMigrationDir() {
 }
 
 export async function getMigrationFiles() {
-  const config = await configHelper.readConfig()
+  const config = configHelper.readConfig()
   if (!config) throw console.error('Migration not initialized yet.')
 
   const migrationDirPath = config.migrationsDir
@@ -34,16 +34,14 @@ export async function getMigrationFiles() {
 }
 
 export async function getAppliedMigrations(db: Db): Promise<IMigrationInfo[]> {
-  const config = await configHelper.readConfig()
+  const config = configHelper.readConfig()
   if (!config) throw console.error('Migration not initialized yet.')
 
-  return db.collection(config.changelogCollectionName).find({}).sort({ _id: -1 }).toArray() as unknown as Promise<
-    IMigrationInfo[]
-  >
+  return db.collection(config.changelogCollectionName).find({}).sort({ _id: -1 }).toArray() as unknown as Promise<IMigrationInfo[]>
 }
 
 export async function getLatestMigrationBatch(db: Db, limit: number = 1) {
-  const config = await configHelper.readConfig()
+  const config = configHelper.readConfig()
   if (!config) throw console.error('Migration not initialized yet.')
 
   const distinctBatches = (await db
@@ -69,21 +67,16 @@ export async function getLatestMigrationBatch(db: Db, limit: number = 1) {
 }
 
 export async function getLatestMigrations(db: Db, limit: number = 1) {
-  const config = await configHelper.readConfig()
+  const config = configHelper.readConfig()
   if (!config) throw console.error('Migration not initialized yet.')
 
-  return db
-    .collection(config.changelogCollectionName)
-    .find({})
-    .sort({ _id: -1 })
-    .limit(limit)
-    .toArray() as unknown as Promise<IMigrationInfo[]>
+  return db.collection(config.changelogCollectionName).find({}).sort({ _id: -1 }).limit(limit).toArray() as unknown as Promise<
+    IMigrationInfo[]
+  >
 }
 
 export async function getMigrationForFile(fileName: string, db: Db) {
-  const config = await configHelper.readConfig()
+  const config = configHelper.readConfig()
 
-  return db.collection(config.changelogCollectionName).find({ fileName }).toArray() as unknown as Promise<
-    IMigrationInfo[]
-  >
+  return db.collection(config.changelogCollectionName).find({ fileName }).toArray() as unknown as Promise<IMigrationInfo[]>
 }

--- a/src/samples/migration-config.yaml.txt
+++ b/src/samples/migration-config.yaml.txt
@@ -7,4 +7,4 @@ db-connection:
 
 migrationsDir: migrations
 changelogCollectionName: migrations
-useDefaultTransaction: false
+useDefaultTransaction: true

--- a/src/samples/migration-config.yaml.txt
+++ b/src/samples/migration-config.yaml.txt
@@ -7,3 +7,4 @@ db-connection:
 
 migrationsDir: migrations
 changelogCollectionName: migrations
+useDefaultTransaction: false


### PR DESCRIPTION
Previously the migration was carried out by attaching a global transaction, this was causing an issue for dbs that does not support replication. So the default has been removed and if this behavior is required we can now set it in the config file